### PR TITLE
Revert "Issue #257: changed Projo.forName to actually return null for errors"

### DIFF
--- a/projo/src/main/java/pro/projo/Projo.java
+++ b/projo/src/main/java/pro/projo/Projo.java
@@ -667,7 +667,7 @@ public abstract class Projo
         }
         catch (ClassNotFoundException classNotFound)
         {
-            return null;
+            throw new NoClassDefFoundError(classNotFound.getMessage());
         }
     }
 

--- a/projo/src/test/java/pro/projo/ProjoTest.java
+++ b/projo/src/test/java/pro/projo/ProjoTest.java
@@ -1,5 +1,5 @@
 //                                                                          //
-// Copyright 2019 - 2023 Mirko Raner                                        //
+// Copyright 2019 Mirko Raner                                               //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
 // you may not use this file except in compliance with the License.         //
@@ -193,11 +193,5 @@ public class ProjoTest
         };
         Set<Method> actual = methods.collect(toSet());
         assertEquals(new HashSet<>(Arrays.asList(expected)), actual);
-    }
-
-    @Test
-    public void testProjoForNameWithNonexistentType()
-    {
-        assertNull(Projo.forName("this.class.does.not.Exist"));
     }
 }


### PR DESCRIPTION
Reverts raner/projo#263

This change breaks a downstream project that relies on the incorrect behavior of `Projo.forName` (i.e., `NoClassDefFoundError` instead of returning null pointer).